### PR TITLE
AWS Provider Testing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "3.74.0"
+      version = "4.30.0"
     }
   }
 }
@@ -62,8 +62,8 @@ output "awsDynamicSecretKey" {
 }
 
 provider "aws" {
-  access_key = data.vault_aws_access_credentials.tempAWScreds.access_key
-  secret_key = data.vault_aws_access_credentials.tempAWScreds.secret_key
+  access_key = data.vault_generic_secret.aws_keys.data["aws_access_key"]
+  secret_key = data.vault_generic_secret.aws_keys.data["aws_secret_key"]
   region     = "us-east-1"
 }
 


### PR DESCRIPTION
Further increase lease time for dynamic credentials. Change AWS Provider to use dynamic credentials instead of long term encrypted vault creds.